### PR TITLE
chore: update tracker verified app versions

### DIFF
--- a/patches/src/main/kotlin/app/template/patches/shared/Constants.kt
+++ b/patches/src/main/kotlin/app/template/patches/shared/Constants.kt
@@ -9,7 +9,7 @@ object Constants {
         name = "Cube ACR",
         packageName = "com.catalinagroup.callrecorder",
         appIconColor = 0xE53935,
-        targets = listOf(AppTarget(version = "2.4.281"))
+        targets = listOf(AppTarget(version = "2.4.281", versionCode = 281))
     )
 
     // Universal TV Remote Control by SensusTech
@@ -25,7 +25,7 @@ object Constants {
         name = "Citizen",
         packageName = "sp0n.citizen",
         appIconColor = 0x0066FF,
-        targets = listOf(AppTarget(version = "0.1298.0"))
+        targets = listOf(AppTarget(version = "0.1298.0", versionCode = 1133))
     )
 
 
@@ -138,7 +138,7 @@ object Constants {
         name = "RAR",
         packageName = "com.rarlab.rar",
         appIconColor = 0x4CAF50,
-        targets = listOf(AppTarget(version = "7.20.build131"))
+        targets = listOf(AppTarget(version = "7.22.build132", versionCode = 132))
     )
 
     // m-Indicator — Mumbai Local Train
@@ -186,7 +186,7 @@ object Constants {
         name = "TeraBox",
         packageName = "com.dubox.drive",
         appIconColor = 0x2EAAFF,
-        targets = listOf(AppTarget(version = "4.20.1"))
+        targets = listOf(AppTarget(version = "4.20.1", versionCode = 620))
     )
 
     // SAI — Split APKs Installer by MTV
@@ -218,7 +218,7 @@ object Constants {
         name = "Canva",
         packageName = "com.canva.editor",
         appIconColor = 0x8B3DFF,
-        targets = listOf(AppTarget(version = "2.365.o"))
+        targets = listOf(AppTarget(version = "2.367.0", versionCode = 29613027))
     )
 
     // Clickmate
@@ -282,7 +282,7 @@ object Constants {
         name = "Proton VPN",
         packageName = "ch.protonvpn.android",
         appIconColor = 0x6D4AFF,
-        targets = listOf(AppTarget(version = "5.18.84.0"))
+        targets = listOf(AppTarget(version = "5.19.16.0", versionCode = 605191600))
     )
 
     // NetShare — Mobile Hotspot / Subnet Router
@@ -314,7 +314,7 @@ object Constants {
         name = "Psiphon Pro",
         packageName = "com.psiphon3.subscription",
         appIconColor = 0x6A1B9A,
-        targets = listOf(AppTarget(version = "476"))
+        targets = listOf(AppTarget(version = "479", versionCode = 479))
     )
 
     // Speedtest by Ookla
@@ -362,7 +362,7 @@ object Constants {
         name = "Waze",
         packageName = "com.waze",
         appIconColor = 0x33CCFF,
-        targets = listOf(AppTarget(version = "5.19.0.2"))
+        targets = listOf(AppTarget(version = "5.21.0.0", versionCode = 1030711))
     )
 
     // AccuWeather — Weather Radar & Forecast
@@ -395,7 +395,7 @@ object Constants {
         name = "The Weather Channel",
         packageName = "com.weather.Weather",
         appIconColor = 0x1B6AC9,
-        targets = listOf(AppTarget(version = "16.10.1", versionCode = 1080012982))
+        targets = listOf(AppTarget(version = "16.11.0", versionCode = 1080013045))
     )
 
     // Ninja VPN — Fast & Secure VPN Proxy
@@ -427,7 +427,7 @@ object Constants {
         name = "Windy",
         packageName = "com.windyty.android",
         appIconColor = 0x0FA0EB,
-        targets = listOf(AppTarget(version = "50.1.1"))
+        targets = listOf(AppTarget(version = "50.1.1", versionCode = 5001012))
     )
 
     // TomTom GO Navigation


### PR DESCRIPTION
- `Cube ACR`: `2.4.281` -> `2.4.281` (`versionCode 281`)
- `Citizen`: `0.1298.0` -> `0.1298.0` (`versionCode 1133`)
- `RAR`: `7.20.build131` -> `7.22.build132` (`versionCode 132`)
- `TeraBox`: `4.20.1` -> `4.20.1` (`versionCode 620`)
- `Canva`: `2.365.o` -> `2.367.0` (`versionCode 29613027`)
- `Proton VPN`: `5.18.84.0` -> `5.19.16.0` (`versionCode 605191600`)
- `Psiphon Pro`: `476` -> `479` (`versionCode 479`)
- `Waze`: `5.19.0.2` -> `5.21.0.0` (`versionCode 1030711`)
- `The Weather Channel`: `16.10.1` -> `16.11.0` (`versionCode 1080013045`)
- `Windy`: `50.1.1` -> `50.1.1` (`versionCode 5001012`)