### PR TITLE
chore: update verified app versions

### DIFF
--- a/patches/src/main/kotlin/app/template/patches/shared/Constants.kt
+++ b/patches/src/main/kotlin/app/template/patches/shared/Constants.kt
@@ -370,7 +370,7 @@ object Constants {
         name = "AccuWeather",
         packageName = "com.accuweather.android",
         appIconColor = 0xF25C1B,
-        targets = listOf(AppTarget(version = "21.1.12-2-rc", versionCode = 210112002))
+        targets = listOf(AppTarget(version = "21.1.13-1-rc", versionCode = 210113001))
     )
 
     // Windscribe VPN
@@ -378,7 +378,7 @@ object Constants {
         name = "Windscribe VPN",
         packageName = "com.windscribe.vpn",
         appIconColor = 0x00AEEF,
-        targets = listOf(AppTarget(version = "4.1.2284", versionCode = 2284))
+        targets = listOf(AppTarget(version = "4.2.2326", versionCode = 2326))
     )
 
     // MovieBox TV by Transsion/Mbox
@@ -467,7 +467,7 @@ object Constants {
         name = "Yoga",
         packageName = "air.com.musclemotion.yoga",
         appIconColor = 0x7B1FA2,
-        targets = listOf(AppTarget(version = "3.2.0", versionCode = 1004178))
+        targets = listOf(AppTarget(version = "3.2.1", versionCode = 1004178))
     )
 
     // Anatomy by Muscle Motion
@@ -571,7 +571,7 @@ object Constants {
         name = "Lawfully",
         packageName = "com.lawfully.lawfully_ai_tracker",
         appIconColor = 0x0D47A1,
-        targets = listOf(AppTarget(version = "6.6.2", versionCode = 532))
+        targets = listOf(AppTarget(version = "6.7.1", versionCode = 534))
     )
 
     // MigraConnect — USCIS & EOIR Case Tracker (com.tecso.MigraConnect)
@@ -819,6 +819,6 @@ object Constants {
         name = "VIZ Manga",
         packageName = "com.vizmanga.android",
         appIconColor = 0xE53935,
-        targets = listOf(AppTarget(version = "4.13.5", versionCode = 227))
+        targets = listOf(AppTarget(version = "4.14.0", versionCode = 232))
     )
 }


### PR DESCRIPTION
- `AccuWeather`: `21.1.12-2-rc` -> `21.1.13-1-rc` (`versionCode 210113001`)
- `Windscribe VPN`: `4.1.2284` -> `4.2.2326` (`versionCode 2326`)
- `Yoga`: `3.2.0` -> `3.2.1`
- `Lawfully`: `6.6.2` -> `6.7.1` (`versionCode 534`)
- `VIZ Manga`: `4.13.5` -> `4.14.0` (`versionCode 232`)