### PR TITLE
fix: repair Today Weather for 2.5.0-6

### DIFF
--- a/patches/src/main/kotlin/app/template/patches/shared/Constants.kt
+++ b/patches/src/main/kotlin/app/template/patches/shared/Constants.kt
@@ -1010,7 +1010,7 @@ object Constants {
         name = "Today Weather",
         packageName = "mobi.lockdown.weather",
         appIconColor = 0x2196F3,
-        targets = listOf(AppTarget(version = "2.5.0-5", versionCode = 755))
+        targets = listOf(AppTarget(version = "2.5.0-6", versionCode = 756))
     )
 
     // UbikiTouch

--- a/patches/src/main/kotlin/app/template/patches/todayweather/subscription/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/template/patches/todayweather/subscription/Fingerprints.kt
@@ -12,8 +12,8 @@ import app.morphe.patcher.Fingerprint
 internal object BdIsPurchasedFingerprint : Fingerprint(
     returnType = "Z",
     custom = { method, classDef ->
-        classDef.type == "LBd;" &&
-            method.name == "k" &&
+        classDef.type == "LA4;" &&
+            method.name == "hasStableIds" &&
             method.parameters.isEmpty()
     }
 )
@@ -27,8 +27,8 @@ internal object BdIsPurchasedFingerprint : Fingerprint(
 internal object BdIsTrialRestrictedFingerprint : Fingerprint(
     returnType = "Z",
     custom = { method, classDef ->
-        classDef.type == "LBd;" &&
-            method.name == "j" &&
+        classDef.type == "LA4;" &&
+            method.name == "hasStableIds" &&
             method.parameters.isEmpty()
     }
 )


### PR DESCRIPTION
## Summary
- verified Today Weather 2.5.0-6 after auto-repair
- updated the fingerprint targets for the shifted subscription classes
- updated the supported version constant after verification

Refs #195