### PR TITLE
fix: repair komoot for 2026.29.0

### DIFF
--- a/patches/src/main/kotlin/app/template/patches/komoot/subscription/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/template/patches/komoot/subscription/Fingerprints.kt
@@ -60,7 +60,7 @@ internal val UserIsPremiumFingerprint = Fingerprint(
  * Called by gpj.s1() to choose the owned vs upsell code path.
  */
 internal val OwnedRegionIsOwnedFingerprint = Fingerprint(
-    definingClass = "Lcin;",
+    definingClass = "Ln2o;",
     name = "n",
     returnType = "Z",
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
@@ -78,7 +78,7 @@ internal val OwnedRegionIsOwnedFingerprint = Fingerprint(
  * always set to true before H0 even runs, covering all code paths.
  */
 internal val RegionsDataOwnsWorldPackFingerprint = Fingerprint(
-    definingClass = "Lbqr;",
+    definingClass = "Lcn2;",
     name = "g",
     returnType = "Z",
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),

--- a/patches/src/main/kotlin/app/template/patches/shared/Constants.kt
+++ b/patches/src/main/kotlin/app/template/patches/shared/Constants.kt
@@ -430,7 +430,7 @@ val KOMOOT_COMPATIBILITY = Compatibility(
         packageName = "de.komoot.android",
         apkFileType = ApkFileType.APKS,
         appIconColor = 0x65AB1E,
-        targets = listOf(AppTarget(version = "2026.28.2", versionCode = 263708003))
+        targets = listOf(AppTarget(version = "2026.29.0", versionCode = 263710002))
     )
 
 val KYPHOSIS_COMPATIBILITY = Compatibility(


### PR DESCRIPTION
- `komoot`: verified `2026.29.0` (`versionCode 263710002`)
- Auto-repair: RegionsDataOwnsWorldPackFingerprint: `Lcn2;`/`g`; OwnedRegionIsOwnedFingerprint: `Ln2o;`/`n`
