### PR TITLE
fix: repair Moovit for 5.196.0.1794

### DIFF
--- a/patches/src/main/kotlin/app/template/patches/shared/Constants.kt
+++ b/patches/src/main/kotlin/app/template/patches/shared/Constants.kt
@@ -986,7 +986,7 @@ val TRANZMATE_COMPATIBILITY = Compatibility(
         packageName = "com.tranzmate",
         apkFileType = ApkFileType.APKS,
         appIconColor = 0x0066FF,
-        targets = listOf(AppTarget(version = "5.195.2.1792", versionCode = 1792))
+        targets = listOf(AppTarget(version = "5.196.0.1794", versionCode = 1794))
     )
 
 val TURBOSCAN_COMPATIBILITY = Compatibility(

--- a/patches/src/main/kotlin/app/template/patches/tranzmate/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/template/patches/tranzmate/Fingerprints.kt
@@ -61,7 +61,7 @@ val PromoCellFragmentOnViewCreatedFingerprint = Fingerprint(
 )
 
 val BlockPaywallGateFingerprint = Fingerprint(
-    definingClass = "Lx81;",
+    definingClass = "Ly81;",
     name = "a",
     returnType = "Z",
     parameters = listOf("Lcom/moovit/MoovitActivity;"),
@@ -118,7 +118,7 @@ val ItineraryBlockedSmartTipsBannerFingerprint = Fingerprint(
 )
 
 val MyMoovitPlusGoPremiumCardFingerprint = Fingerprint(
-    definingClass = "Lxy9;",
+    definingClass = "Lzy9;",
     name = "emit",
     returnType = "Ljava/lang/Object;",
     parameters = listOf("Ljava/lang/Object;", "Llx2;"),


### PR DESCRIPTION
- `Moovit`: verified `5.196.0.1794` (`versionCode 1794`)
- Auto-repair: BlockPaywallGateFingerprint: `Ly81;`/`a`; MyMoovitPlusGoPremiumCardFingerprint: `Lzy9;`/`emit`
