### PR TITLE
fix: repair Carousell for 2.462.7

### DIFF
--- a/patches/src/main/kotlin/app/template/patches/carousell/CarousellFingerprints.kt
+++ b/patches/src/main/kotlin/app/template/patches/carousell/CarousellFingerprints.kt
@@ -20,7 +20,7 @@ internal object ExcludePromotedProfileFingerprint : Fingerprint(
 
 // AdLoadManagerImpl.g() — interstitial ad loader; return Observable.empty()
 internal object AdLoadManagerLoadInterstitialFingerprint : Fingerprint(
-    definingClass = "Lij1/h;",
+    definingClass = "Lsj1/h;",
     name = "g",
     returnType = "Lio/reactivex/r;",
     parameters = listOf(
@@ -33,7 +33,7 @@ internal object AdLoadManagerLoadInterstitialFingerprint : Fingerprint(
 
 // AdLoadManagerImpl.d() — banner/native ad loader; return Observable.empty()
 internal object AdLoadManagerLoadBannerFingerprint : Fingerprint(
-    definingClass = "Lij1/h;",
+    definingClass = "Lsj1/h;",
     name = "d",
     returnType = "Lio/reactivex/r;",
     parameters = listOf(

--- a/patches/src/main/kotlin/app/template/patches/shared/Constants.kt
+++ b/patches/src/main/kotlin/app/template/patches/shared/Constants.kt
@@ -181,7 +181,7 @@ val CAROUSELL_COMPATIBILITY = Compatibility(
         name = "Carousell",
         packageName = "com.thecarousell.Carousell",
         appIconColor = 0xE7392C,
-        targets = listOf(AppTarget(version = "2.461.8", versionCode = 10767))
+        targets = listOf(AppTarget(version = "2.462.7", versionCode = 10793))
     )
 
 val CASETRACKER_COMPATIBILITY = Compatibility(


### PR DESCRIPTION
- `Carousell`: verified `2.462.7` (`versionCode 10793`)
- Auto-repair: AdLoadManagerLoadInterstitialFingerprint: `Lsj1/h;`/`g`; AdLoadManagerLoadBannerFingerprint: `Lsj1/h;`/`d`
