### PR TITLE
fix: repair Lark Player for 2026.10.5

### DIFF
--- a/patches/src/main/kotlin/app/template/patches/larkplayer/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/template/patches/larkplayer/Fingerprints.kt
@@ -20,7 +20,7 @@ internal val HasPurchaseFingerprint = Fingerprint(
         opcode(Opcode.IF_EQZ),
     ),
     custom = { method, classDef ->
-        classDef.type == "Lo/b15;" && method.name == "d"
+        classDef.type == "Lo/a15;" && method.name == "d"
     }
 )
 
@@ -41,7 +41,7 @@ internal val HasHistoryPurchaseFingerprint = Fingerprint(
         opcode(Opcode.IF_EQZ),
     ),
     custom = { method, classDef ->
-        classDef.type == "Lo/b15;" && method.name == "J"
+        classDef.type == "Lo/a15;" && method.name == "J"
     }
 )
 
@@ -70,6 +70,6 @@ internal val IsPermanentFingerprint = Fingerprint(
         opcode(Opcode.INVOKE_DIRECT),
     ),
     custom = { method, classDef ->
-        classDef.type == "Lo/b15;" && method.name == "f"
+        classDef.type == "Lo/a15;" && method.name == "f"
     }
 )

--- a/patches/src/main/kotlin/app/template/patches/shared/Constants.kt
+++ b/patches/src/main/kotlin/app/template/patches/shared/Constants.kt
@@ -445,7 +445,7 @@ val LARK_PLAYER_COMPATIBILITY = Compatibility(
         packageName = "com.dywx.larkplayer",
         apkFileType = ApkFileType.APKS,
         appIconColor = 0x1DB954,
-        targets = listOf(AppTarget(version = "2026.9.6", versionCode = 2026090609))
+        targets = listOf(AppTarget(version = "2026.10.5", versionCode = 2026100509))
     )
 
 val LAWFULLY_COMPATIBILITY = Compatibility(


### PR DESCRIPTION
- `Lark Player`: verified `2026.10.5` (`versionCode 2026100509`)
- Auto-repair: HasPurchaseFingerprint: `Lo/a15;`/`d`; HasHistoryPurchaseFingerprint: `Lo/a15;`/`J`; IsPermanentFingerprint: `Lo/a15;`/`f`
