### PR TITLE
fix: repair TomTom GO for 3.6.320

### DIFF
--- a/patches/src/main/kotlin/app/template/patches/shared/Constants.kt
+++ b/patches/src/main/kotlin/app/template/patches/shared/Constants.kt
@@ -941,7 +941,7 @@ val TOMTOMGO_COMPATIBILITY = Compatibility(
         name = "TomTom GO",
         packageName = "com.tomtom.gplay.navapp",
         appIconColor = 0xDF1B12,
-        targets = listOf(AppTarget(version = "3.6.316-beta", versionCode = 1678657))
+        targets = listOf(AppTarget(version = "3.6.320", versionCode = 1678697))
     )
 
 val TOOMICS_COMPATIBILITY = Compatibility(

--- a/patches/src/main/kotlin/app/template/patches/tomtomgo/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/template/patches/tomtomgo/Fingerprints.kt
@@ -150,14 +150,14 @@ object SubscriptionDetailsIsTruckFingerprint : Fingerprint(
 
 object BillingPurchaseStarterFingerprint : Fingerprint(
     definingClass = "Lpb/a;",
-    name = "k3",
+    name = "l3",
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
     returnType = "LCj/u;",
     parameters = listOf("Landroid/app/Activity;", "Ltb/b;"),
 )
 
 object CurrentSubscriptionFingerprint : Fingerprint(
-    definingClass = "Le9/o2;",
+    definingClass = "Le9/u2;",
     name = "J1",
     accessFlags = listOf(AccessFlags.PUBLIC, AccessFlags.FINAL),
     returnType = "Ltb/a;",


### PR DESCRIPTION
- `TomTom GO`: verified `3.6.320` (`versionCode 1678697`)
- Auto-repair: CurrentSubscriptionFingerprint: `Le9/u2;`/`J1`; BillingPurchaseStarterFingerprint: `Lpb/a;`/`l3`
