### PR TITLE
chore: update verified app versions

### DIFF
--- a/patches/src/main/kotlin/app/template/patches/shared/Constants.kt
+++ b/patches/src/main/kotlin/app/template/patches/shared/Constants.kt
@@ -61,7 +61,7 @@ val AMAZON_SHOPPING_COMPATIBILITY = Compatibility(
         name = "Amazon Shopping",
         packageName = "com.amazon.mShop.android.shopping",
         appIconColor = 0xFF9900,
-        targets = listOf(AppTarget(version = "32.12.4.100", versionCode = 1241319416))
+        targets = listOf(AppTarget(version = "32.13.0.100", versionCode = 1241320016))
     )
 
 val AMBOSS_COMPATIBILITY = Compatibility(
@@ -160,7 +160,7 @@ val CAMSCANNER_COMPATIBILITY = Compatibility(
         packageName = "com.intsig.camscanner",
         apkFileType = ApkFileType.APKS,
         appIconColor = 0x19BCAA,
-        targets = listOf(AppTarget(version = "7.20.5.2606250000", versionCode = 72051))
+        targets = listOf(AppTarget(version = "7.21.0.2607010000", versionCode = 72101))
     )
 
 val CANVA_COMPATIBILITY = Compatibility(
@@ -209,7 +209,7 @@ val CITYMAPPER_COMPATIBILITY = Compatibility(
         name = "Citymapper",
         packageName = "com.citymapper.app.release",
         appIconColor = 0x00A862,
-        targets = listOf(AppTarget(version = "11.55.1", versionCode = 1155080))
+        targets = listOf(AppTarget(version = "11.55.2", versionCode = 1155090))
     )
 
 val COLORNOTE_COMPATIBILITY = Compatibility(
@@ -298,7 +298,7 @@ val FLIGHTAWARE_COMPATIBILITY = Compatibility(
         name = "FlightAware",
         packageName = "com.flightaware.android.liveFlightTracker",
         appIconColor = 0x1565C0,
-        targets = listOf(AppTarget(version = "5.15.4", versionCode = 501500400))
+        targets = listOf(AppTarget(version = "5.15.5", versionCode = 501500500))
     )
 
 val FLIGHTRADAR_COMPATIBILITY = Compatibility(
@@ -467,7 +467,7 @@ val LIVESCORE_COMPATIBILITY = Compatibility(
         name = "LiveScore",
         packageName = "com.livescore",
         appIconColor = 0xE30613,
-        targets = listOf(AppTarget(version = "9.7.1", versionCode = 2072))
+        targets = listOf(AppTarget(version = "9.8", versionCode = 2088))
     )
 
 val MEGA_COMPATIBILITY = Compatibility(
@@ -561,7 +561,7 @@ val NAVITIME_COMPATIBILITY = Compatibility(
         packageName = "com.navitime.inbound.walk",
         apkFileType = ApkFileType.APKS,
         appIconColor = 0x003087,
-        targets = listOf(AppTarget(version = "12.0.1", versionCode = 363))
+        targets = listOf(AppTarget(version = "12.0.2", versionCode = 364))
     )
 
 val NETGUARD_COMPATIBILITY = Compatibility(
@@ -604,7 +604,7 @@ val NYT_GAMES_COMPATIBILITY = Compatibility(
         packageName = "com.nytimes.crossword",
         apkFileType = ApkFileType.APKS,
         appIconColor = 0x000000,
-        targets = listOf(AppTarget(version = "6.33.1", versionCode = 6426456))
+        targets = listOf(AppTarget(version = "6.34.0", versionCode = 6426458))
     )
 
 val NZB360_COMPATIBILITY = Compatibility(
@@ -786,7 +786,7 @@ val SCOOPZ_COMPATIBILITY = Compatibility(
         name = "Scoopz",
         packageName = "com.localaiapp.scoops",
         appIconColor = 0xE53935,
-        targets = listOf(AppTarget(version = "3.28.0", versionCode = 3280007))
+        targets = listOf(AppTarget(version = "3.29.0", versionCode = 3290002))
     )
 
 val SCRL_COMPATIBILITY = Compatibility(
@@ -816,7 +816,7 @@ val SKINSORT_COMPATIBILITY = Compatibility(
         name = "SkinSort",
         packageName = "com.skinsort",
         appIconColor = 0x2F7D62,
-        targets = listOf(AppTarget(version = "1.20", versionCode = 31))
+        targets = listOf(AppTarget(version = "1.21", versionCode = 33))
     )
 
 val SNIPD_COMPATIBILITY = Compatibility(
@@ -978,7 +978,7 @@ val TRADINGVIEW_COMPATIBILITY = Compatibility(
         packageName = "com.tradingview.tradingviewapp",
         apkFileType = ApkFileType.APKS,
         appIconColor = 0x2962FF,
-        targets = listOf(AppTarget(version = "1.20.78.0.1002325", versionCode = 1002325))
+        targets = listOf(AppTarget(version = "1.20.78.1.1002330", versionCode = 1002330))
     )
 
 val TRANZMATE_COMPATIBILITY = Compatibility(


### PR DESCRIPTION
- `Amazon Shopping`: `32.12.4.100` -> `32.13.0.100` (`versionCode 1241320016`)
- `CamScanner`: `7.20.5.2606250000` -> `7.21.0.2607010000` (`versionCode 72101`)
- `Citymapper`: `11.55.1` -> `11.55.2` (`versionCode 1155090`)
- `FlightAware`: `5.15.4` -> `5.15.5` (`versionCode 501500500`)
- `LiveScore`: `9.7.1` -> `9.8` (`versionCode 2088`)
- `NAVITIME`: `12.0.1` -> `12.0.2` (`versionCode 364`)
- `NYT Games`: `6.33.1` -> `6.34.0` (`versionCode 6426458`)
- `Scoopz`: `3.28.0` -> `3.29.0` (`versionCode 3290002`)
- `SkinSort`: `1.20` -> `1.21` (`versionCode 33`)
- `TradingView`: `1.20.78.0.1002325` -> `1.20.78.1.1002330` (`versionCode 1002330`)