### PR TITLE
fix: repair Carousell for 2.463.9

### DIFF
--- a/patches/src/main/kotlin/app/template/patches/carousell/CarousellFingerprints.kt
+++ b/patches/src/main/kotlin/app/template/patches/carousell/CarousellFingerprints.kt
@@ -20,8 +20,8 @@ internal object ExcludePromotedProfileFingerprint : Fingerprint(
 
 // AdLoadManagerImpl.g() — interstitial ad loader; return Observable.empty()
 internal object AdLoadManagerLoadInterstitialFingerprint : Fingerprint(
-    definingClass = "Lij1/h;",
-    name = "g",
+    definingClass = "Luj1/h;",
+    name = "f",
     returnType = "Lio/reactivex/r;",
     parameters = listOf(
         "Lcom/thecarousell/data/external_ads/model/AdLoadConfigNew;",
@@ -33,8 +33,8 @@ internal object AdLoadManagerLoadInterstitialFingerprint : Fingerprint(
 
 // AdLoadManagerImpl.d() — banner/native ad loader; return Observable.empty()
 internal object AdLoadManagerLoadBannerFingerprint : Fingerprint(
-    definingClass = "Lij1/h;",
-    name = "d",
+    definingClass = "Luj1/h;",
+    name = "c",
     returnType = "Lio/reactivex/r;",
     parameters = listOf(
         "Lcom/thecarousell/data/external_ads/model/AdLoadConfigNew;",

--- a/patches/src/main/kotlin/app/template/patches/shared/Constants.kt
+++ b/patches/src/main/kotlin/app/template/patches/shared/Constants.kt
@@ -181,7 +181,8 @@ val CAROUSELL_COMPATIBILITY = Compatibility(
         name = "Carousell",
         packageName = "com.thecarousell.Carousell",
         appIconColor = 0xE7392C,
-        targets = listOf(AppTarget(version = "2.461.8", versionCode = 10767))
+        apkFileType = ApkFileType.XAPK,
+        targets = listOf(AppTarget(version = "2.463.9", versionCode = 10820))
     )
 
 val CASETRACKER_COMPATIBILITY = Compatibility(


### PR DESCRIPTION
- `Carousell`: verified `2.463.9` (`versionCode 10820`)
- Auto-repair: AdLoadManagerLoadInterstitialFingerprint: `Luj1/h;`/`f`; AdLoadManagerLoadBannerFingerprint: `Luj1/h;`/`c`
