### PR TITLE
fix: repair Pixel Habit Tracker for 2.1.3

### DIFF
--- a/patches/src/main/kotlin/app/template/patches/pixelhabittracker/pro/PixelHabitTrackerFingerprints.kt
+++ b/patches/src/main/kotlin/app/template/patches/pixelhabittracker/pro/PixelHabitTrackerFingerprints.kt
@@ -13,7 +13,7 @@ import app.morphe.patcher.Fingerprint
  * Use "billing_prefs" + "pro_purchased" to uniquely match the constructor.
  */
 object PurchaseRepositoryConstructorFingerprint : Fingerprint(
-    definingClass = "Lhh2;",
+    definingClass = "Lfi2;",
     returnType = "V",
     parameters = listOf("Landroid/content/Context;"),
     strings = listOf("billing_prefs", "pro_purchased"),
@@ -28,7 +28,7 @@ object PurchaseRepositoryConstructorFingerprint : Fingerprint(
  * compareAndSet(null, newValue) — first arg is always null (the UNSET sentinel).
  */
 object ProStateSetterFingerprint : Fingerprint(
-    definingClass = "Lhh2;",
+    definingClass = "Lfi2;",
     returnType = "V",
     parameters = listOf("Z"),
     strings = listOf("pro_purchased"),

--- a/patches/src/main/kotlin/app/template/patches/shared/Constants.kt
+++ b/patches/src/main/kotlin/app/template/patches/shared/Constants.kt
@@ -678,7 +678,7 @@ val PIXEL_HABIT_TRACKER_COMPATIBILITY = Compatibility(
         packageName = "com.pixel.al.pixelhabittracker",
         apkFileType = ApkFileType.XAPK,
         appIconColor = 0xFF6B35,
-        targets = listOf(AppTarget(version = "2.1.2", versionCode = 100063))
+        targets = listOf(AppTarget(version = "2.1.3", versionCode = 100065))
     )
 
 val PKGE_COMPATIBILITY = Compatibility(


### PR DESCRIPTION
- `Pixel Habit Tracker`: verified `2.1.3` (`versionCode 100065`)
- Auto-repair: ProStateSetterFingerprint: `Lfi2;`/`f`; PurchaseRepositoryConstructorFingerprint: `Lfi2;`/`<init>`
