### PR TITLE
fix: allow Amazon dark mode styles on builds without values-v29

### DIFF
--- a/patches/src/main/kotlin/app/template/patches/amazon/darkmode/DarkModePatch.kt
+++ b/patches/src/main/kotlin/app/template/patches/amazon/darkmode/DarkModePatch.kt
@@ -12,12 +12,20 @@ private const val HELPER = "Lapp/template/extension/extension/AmazonHelper;"
 
 private val amazonDarkModeResourcePatch = resourcePatch {
     execute {
-        document("res/values-v29/styles.xml").use { doc ->
-            val items = doc.getElementsByTagName("item")
-            for (i in 0 until items.length) {
-                val item = items.item(i) as? Element ?: continue
-                if (item.getAttribute("name") == "android:forceDarkAllowed")
-                    item.textContent = "true"
+        // Newer Amazon builds keep forceDarkAllowed in values/styles.xml;
+        // older builds used values-v29. Update whichever files exist.
+        listOf(
+            "res/values/styles.xml",
+            "res/values-v29/styles.xml",
+        ).forEach { path ->
+            if (!get(path).exists()) return@forEach
+            document(path).use { doc ->
+                val items = doc.getElementsByTagName("item")
+                for (i in 0 until items.length) {
+                    val item = items.item(i) as? Element ?: continue
+                    if (item.getAttribute("name") == "android:forceDarkAllowed")
+                        item.textContent = "true"
+                }
             }
         }
     }

--- a/patches/src/main/kotlin/app/template/patches/amazon/darkmode/DarkModePatch.kt
+++ b/patches/src/main/kotlin/app/template/patches/amazon/darkmode/DarkModePatch.kt
@@ -17,8 +17,7 @@ private val amazonDarkModeResourcePatch = resourcePatch {
         listOf(
             "res/values/styles.xml",
             "res/values-v29/styles.xml",
-        ).forEach { path ->
-            if (!get(path).exists()) return@forEach
+        ).filter { get(it).exists() }.forEach { path ->
             document(path).use { doc ->
                 val items = doc.getElementsByTagName("item")
                 for (i in 0 until items.length) {


### PR DESCRIPTION
## Summary
- Amazon Shopping 32.13+ stores `android:forceDarkAllowed` in `res/values/styles.xml` and no longer ships `res/values-v29/styles.xml`
- The Dark mode resource patch now updates whichever of those files exist, avoiding the ENOENT crash when `values-v29` is missing

## Test plan
- [x] Decode Amazon Shopping 32.13.0.100 and confirm `forceDarkAllowed` is only in `res/values/styles.xml`
- [x] Build patches and apply Dark mode exclusively via Morphe CLI to a merged APKM
- [x] Confirm both theme items become `forceDarkAllowed=true` and patching succeeds with no failed patches

Made with [Cursor](https://cursor.com)