### PR TITLE
Add Telegram Disable Rich HTML Paste patch

### DIFF
--- a/patches/src/main/kotlin/app/template/patches/telegram/TelegramFingerprints.kt
+++ b/patches/src/main/kotlin/app/template/patches/telegram/TelegramFingerprints.kt
@@ -768,3 +768,11 @@ val AnalyticsTrackEventMapFingerprint = Fingerprint(
     returnType = "V",
     parameters = listOf("Ljava/lang/String;", "Ljava/util/HashMap;"),
 )
+
+// ─── Rich HTML paste ──────────────────────────────────────────────────────────
+val ChatActivityEnterViewHandleRichHtmlPasteFingerprint = Fingerprint(
+    definingClass = "Lorg/telegram/ui/Components/ChatActivityEnterView;",
+    name = "handleRichHtmlPaste",
+    returnType = "Z",
+    parameters = listOf(),
+)

--- a/patches/src/main/kotlin/app/template/patches/telegram/content/TelegramDisableRichHtmlPastePatch.kt
+++ b/patches/src/main/kotlin/app/template/patches/telegram/content/TelegramDisableRichHtmlPastePatch.kt
@@ -1,0 +1,30 @@
+package app.template.patches.telegram.content
+
+import app.morphe.patcher.extensions.InstructionExtensions.addInstructions
+import app.morphe.patcher.patch.bytecodePatch
+import app.template.patches.shared.Constants.TELEGRAM_COMPATIBILITY
+import app.template.patches.shared.Constants.TELEGRAM_PLUS_COMPATIBILITY
+import app.template.patches.shared.Constants.TELEGRAM_WEB_COMPATIBILITY
+import app.template.patches.telegram.ChatActivityEnterViewHandleRichHtmlPasteFingerprint
+
+@Suppress("unused")
+val telegramDisableRichHtmlPastePatch = bytecodePatch(
+    name = "Use normal paste for Rich HTML clipboard content",
+    description = "Skips Telegram's Rich HTML paste handler and falls back to the normal paste path.",
+) {
+    compatibleWith(
+        TELEGRAM_COMPATIBILITY,
+        TELEGRAM_WEB_COMPATIBILITY,
+        TELEGRAM_PLUS_COMPATIBILITY,
+    )
+
+    execute {
+        ChatActivityEnterViewHandleRichHtmlPasteFingerprint.method.addInstructions(
+            0,
+            """
+                const/4 v0, 0x0
+                return v0
+            """,
+        )
+    }
+}


### PR DESCRIPTION

Adds a patch for Telegram that disables rich HTML formatting when pasting text.

This ensures pasted content is inserted as plain text instead of preserving HTML formatting, styles, links, or other rich-text attributes.