### PR TITLE
Add Telegram Rich Message forwarding Hide Sender fix Patch & Zee5 Mobile Patches

### DIFF
--- a/patches/src/main/kotlin/app/template/patches/shared/Constants.kt
+++ b/patches/src/main/kotlin/app/template/patches/shared/Constants.kt
@@ -2035,6 +2035,13 @@ val YATRI_COMPATIBILITY = Compatibility(
         targets = listOf(AppTarget(version = "5.0.6", versionCode = 1013))
     )
 
+val ZEE5_COMPATIBILITY = Compatibility(
+        name = "ZEE5",
+        packageName = "com.graymatrix.did",
+        apkFileType = ApkFileType.APKM,
+        targets = listOf(AppTarget(version = "39.56.7", versionCode = 204312578))
+    )
+
 val COMPATIBILITY_DOOFLIX = Compatibility(
         name = "DooFlix",
         packageName = "com.king.moja",

--- a/patches/src/main/kotlin/app/template/patches/telegram/TelegramFingerprints.kt
+++ b/patches/src/main/kotlin/app/template/patches/telegram/TelegramFingerprints.kt
@@ -776,3 +776,18 @@ val ChatActivityEnterViewHandleRichHtmlPasteFingerprint = Fingerprint(
     returnType = "Z",
     parameters = listOf(),
 )
+
+// ─── Rich-message forwarding / Hide Sender Name ───────────────────────────────
+val ChatActivityForwardMessagesFingerprint = Fingerprint(
+    definingClass = "Lorg/telegram/ui/ChatActivity;",
+    name = "forwardMessages",
+    returnType = "V",
+    parameters = listOf(
+        "Ljava/util/ArrayList;",
+        "Z",
+        "Z",
+        "Z",
+        "I",
+        "J",
+    ),
+)

--- a/patches/src/main/kotlin/app/template/patches/telegram/content/TelegramHideRichMessageForwardedSenderPatch.kt
+++ b/patches/src/main/kotlin/app/template/patches/telegram/content/TelegramHideRichMessageForwardedSenderPatch.kt
@@ -1,0 +1,52 @@
+package app.template.patches.telegram.content
+
+import app.morphe.patcher.patch.bytecodePatch
+import app.template.patches.shared.Constants.TELEGRAM_COMPATIBILITY
+import app.template.patches.shared.Constants.TELEGRAM_PLUS_COMPATIBILITY
+import app.template.patches.shared.Constants.TELEGRAM_WEB_COMPATIBILITY
+import app.template.patches.telegram.ChatActivityForwardMessagesFingerprint
+
+/**
+ * Telegram 12.10.1 Rich Message forwarding fix.
+ *
+ * When the selected message is a Rich Message, force the existing
+ * SendMessagesHelper "fromMyName" argument to true. That causes the normal
+ * forwarding request to set messages.forwardMessages.drop_author=true.
+ *
+ * This keeps the original message/content; it only removes the forwarded
+ * sender attribution.
+ *
+ * NOTE: This is intentionally rich-message-only. Therefore ordinary text,
+ * photo, video, etc. forwards retain Telegram's normal behavior.
+ */
+@Suppress("unused")
+val telegramHideRichMessageForwardedSenderPatch = bytecodePatch(
+    name = "Hide sender name for Rich Message forwards",
+    description = "Removes the forwarded channel attribution for Rich Messages while preserving the original message.",
+) {
+    compatibleWith(
+        TELEGRAM_COMPATIBILITY,
+        TELEGRAM_WEB_COMPATIBILITY,
+        TELEGRAM_PLUS_COMPATIBILITY,
+    )
+
+    execute {
+        ChatActivityForwardMessagesFingerprint.method.addInstructions(
+            0,
+            """
+                if-eqz p1, :rich_forward_done
+                invoke-virtual {p1}, Ljava/util/ArrayList;->isEmpty()Z
+                move-result v0
+                if-nez v0, :rich_forward_done
+                const/4 v0, 0x0
+                invoke-virtual {p1, v0}, Ljava/util/ArrayList;->get(I)Ljava/lang/Object;
+                move-result-object v0
+                check-cast v0, Lorg/telegram/messenger/MessageObject;
+                iget-object v0, v0, Lorg/telegram/tgnet/TLRPC$Message;->rich_message:Lorg/telegram/tgnet/tl/TL_iv$RichMessage;
+                if-eqz v0, :rich_forward_done
+                const/4 p2, 0x1
+            :rich_forward_done
+            """,
+        )
+    }
+}

--- a/patches/src/main/kotlin/app/template/patches/zee5/ads/DisplayAdFingerprints.kt
+++ b/patches/src/main/kotlin/app/template/patches/zee5/ads/DisplayAdFingerprints.kt
@@ -1,0 +1,27 @@
+package app.template.patches.zee5.ads
+
+import app.morphe.patcher.Fingerprint
+
+private fun booleanGetter(name: String) = object : Fingerprint(
+    returnType = "Z",
+    parameters = emptyList(),
+    custom = { method, _ -> method.name == name },
+) {}
+
+object RegisteredUserAdsVisibilityFingerprint : Fingerprint(
+    returnType = "Z",
+    parameters = emptyList(),
+    custom = { method, _ -> method.name == "getRegisteredUserAdsVisibility" },
+)
+
+object GuestAdsVisibilityFingerprint : Fingerprint(
+    returnType = "Z",
+    parameters = emptyList(),
+    custom = { method, _ -> method.name == "getGuestAdsVisibility" },
+)
+
+object PremiumUserAdsVisibilityFingerprint : Fingerprint(
+    returnType = "Z",
+    parameters = emptyList(),
+    custom = { method, _ -> method.name == "getPremiumUserAdsVisibility" },
+)

--- a/patches/src/main/kotlin/app/template/patches/zee5/ads/DisplayAdsPatch.kt
+++ b/patches/src/main/kotlin/app/template/patches/zee5/ads/DisplayAdsPatch.kt
@@ -1,0 +1,23 @@
+package app.template.patches.zee5.ads
+
+import app.morphe.patcher.patch.bytecodePatch
+import app.template.patches.shared.Constants.ZEE5_COMPATIBILITY
+import app.template.patches.shared.returnEarly
+
+/**
+ * This intentionally targets the DTO visibility predicate first rather than
+ * deleting the whole ad repository, which can break normal home/content data.
+ */
+@Suppress("unused")
+val zee5DisplayAdsPatch = bytecodePatch(
+    name = "Hide ZEE5 display ads",
+    description = "Disables selected client-side display-ad visibility flags.",
+) {
+    compatibleWith(ZEE5_COMPATIBILITY)
+
+    execute {
+        RegisteredUserAdsVisibilityFingerprint.methodOrNull?.returnEarly(false)
+        GuestAdsVisibilityFingerprint.methodOrNull?.returnEarly(false)
+        PremiumUserAdsVisibilityFingerprint.methodOrNull?.returnEarly(false)
+    }
+}

--- a/patches/src/main/kotlin/app/template/patches/zee5/ads/Fingerprints.kt
+++ b/patches/src/main/kotlin/app/template/patches/zee5/ads/Fingerprints.kt
@@ -1,0 +1,48 @@
+package app.template.patches.zee5.ads
+
+import app.morphe.patcher.Fingerprint
+
+object VideoAdDtoAdsUrlFingerprint : Fingerprint(
+    returnType = "Ljava/lang/String;",
+    parameters = emptyList(),
+    custom = { method, classDef ->
+        classDef.type == "Lcom/zee5/data/network/dto/VideoAdDto;" &&
+            method.name == "getAdsUrl"
+    },
+)
+
+object VideoAdDtoIntervalsFingerprint : Fingerprint(
+    returnType = "Ljava/util/List;",
+    parameters = emptyList(),
+    custom = { method, classDef ->
+        classDef.type == "Lcom/zee5/data/network/dto/VideoAdDto;" &&
+            method.name == "getIntervals"
+    },
+)
+
+object AdsConfigInputAdsUrlFingerprint : Fingerprint(
+    returnType = "Ljava/lang/String;",
+    parameters = emptyList(),
+    custom = { method, classDef ->
+        classDef.type == "Lcom/zee5/usecase/content/GetAdsConfigUseCase$Input;" &&
+            method.name == "getAdsUrl"
+    },
+)
+
+object AdsConfigInputImaAdsFingerprint : Fingerprint(
+    returnType = "Ljava/util/List;",
+    parameters = emptyList(),
+    custom = { method, classDef ->
+        classDef.type == "Lcom/zee5/usecase/content/GetAdsConfigUseCase$Input;" &&
+            method.name == "getImaAdsMetaInfoList"
+    },
+)
+
+object NoPrerollEnabledFingerprint : Fingerprint(
+    returnType = "Z",
+    parameters = emptyList(),
+    custom = { method, classDef ->
+        classDef.type == "Lcom/zee5/data/network/dto/player/NoPrerollAdsInContentDto;" &&
+            method.name == "isEnabled"
+    },
+)

--- a/patches/src/main/kotlin/app/template/patches/zee5/ads/Zee5AdsPatch.kt
+++ b/patches/src/main/kotlin/app/template/patches/zee5/ads/Zee5AdsPatch.kt
@@ -1,0 +1,21 @@
+package app.template.patches.zee5.ads
+
+import app.morphe.patcher.patch.bytecodePatch
+import app.template.patches.shared.Constants.ZEE5_COMPATIBILITY
+import app.template.patches.shared.returnEarly
+
+@Suppress("unused")
+val zee5AdsPatch = bytecodePatch(
+    name = "Remove ZEE5 video ad configuration",
+    description = "Disables the client-side ZEE5 mobile ad configuration path.",
+) {
+    compatibleWith(ZEE5_COMPATIBILITY)
+
+    execute {
+        VideoAdDtoAdsUrlFingerprint.method.returnEarly(null)
+        VideoAdDtoIntervalsFingerprint.method.returnEarly(null)
+        AdsConfigInputAdsUrlFingerprint.method.returnEarly(null)
+        AdsConfigInputImaAdsFingerprint.method.returnEarly(null)
+        NoPrerollEnabledFingerprint.method.returnEarly(false)
+    }
+}


### PR DESCRIPTION
 * When the selected message is a Rich Message, force the existing SendMessagesHelper "fromMyName" argument to true. That causes the normal forwarding request to set messages.forwardMessages.drop_author=true. This keeps the original message/content; it only removes the forwarded sender attribution.
 * NOTE: This is intentionally rich-message-only. Therefore ordinary text, photo, video, etc. forwards retain Telegram's normal behavior.

* Added Zee5 Mobile Patches